### PR TITLE
Salvataggio automatico dei dati Triforce

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1079,7 +1079,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	if(ncfg->Config & NIN_CFG_MEMCARDEMU)
+	if(ncfg->Config & NIN_CFG_MEMCARDEMU || IsTRIGame != 0)
 	{
 		// Memory card emulation is enabled.
 		// Set up the memory card file.


### PR DESCRIPTION
Per salvare i dati dei giochi Triforce, prima era necessario abilitare l'emulazione della Memory Card nelle impostazioni, ma ora non lo è più.
In effetti molta gente si lamentava di non poter salvare questi dati proprio perché non si era accorta di doverlo fare.