### PR TITLE
Impostazione automatica della lingua dei giochi non europei

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1084,7 +1084,7 @@ int main(int argc, char **argv)
 					break;
 			}
 		}
-		else
+		else if(BI2region == BI2_REGION_USA)
 			ncfg->Language = NIN_LAN_ENGLISH;
 	}
 

--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1060,27 +1060,32 @@ int main(int argc, char **argv)
 //Set Language
 	if( (ncfg->Language == NIN_LAN_AUTO || ncfg->Language >= NIN_LAN_LAST) && IsTRIGame == 0 )
 	{
-		switch (CONF_GetLanguage())
+		if(BI2region == BI2_REGION_PAL)
 		{
-			case CONF_LANG_GERMAN:
-				ncfg->Language = NIN_LAN_GERMAN;
-				break;
-			case CONF_LANG_FRENCH:
-				ncfg->Language = NIN_LAN_FRENCH;
-				break;
-			case CONF_LANG_SPANISH:
-				ncfg->Language = NIN_LAN_SPANISH;
-				break;
-			case CONF_LANG_ITALIAN:
-				ncfg->Language = NIN_LAN_ITALIAN;
-				break;
-			case CONF_LANG_DUTCH:
-				ncfg->Language = NIN_LAN_DUTCH;
-				break;
-			default:
-				ncfg->Language = NIN_LAN_ENGLISH;
-				break;
+			switch (CONF_GetLanguage())
+			{
+				case CONF_LANG_GERMAN:
+					ncfg->Language = NIN_LAN_GERMAN;
+					break;
+				case CONF_LANG_FRENCH:
+					ncfg->Language = NIN_LAN_FRENCH;
+					break;
+				case CONF_LANG_SPANISH:
+					ncfg->Language = NIN_LAN_SPANISH;
+					break;
+				case CONF_LANG_ITALIAN:
+					ncfg->Language = NIN_LAN_ITALIAN;
+					break;
+				case CONF_LANG_DUTCH:
+					ncfg->Language = NIN_LAN_DUTCH;
+					break;
+				default:
+					ncfg->Language = NIN_LAN_ENGLISH;
+					break;
+			}
 		}
+		else
+			ncfg->Language = NIN_LAN_ENGLISH;
 	}
 
 	if(ncfg->Config & NIN_CFG_MEMCARDEMU || IsTRIGame != 0)


### PR DESCRIPTION
Nei giochi non europei, se l'impostazione della lingua era su Auto, Nintendont cercava comunque di cambiare la lingua in base alle impostazioni del menu Wii. Non sono molti i giochi non europei ad avere dentro le lingue europee, ma giochi come Metroid Prime 2 costituiscono un'eccezione, e visualizzarli in lingue europee può creare problemi.
Con questo cambiamento, i giochi non europei con l'impostazione di lingua Auto verranno visualizzati sempre in inglese o in giapponese, a seconda della versione regionale.