### PR TITLE
Non creare il file Memory Card per i giochi Triforce

### DIFF
--- a/loader/source/main.c
+++ b/loader/source/main.c
@@ -1124,7 +1124,7 @@ int main(int argc, char **argv)
 		snprintf(MemCard, sizeof(MemCard), "%s/%s.raw", BasePath, MemCardName);
 		gprintf("Using %s as Memory Card.\r\n", MemCard);
 		FIL f;
-		if (f_open_char(&f, MemCard, FA_READ|FA_OPEN_EXISTING) != FR_OK)
+		if ( (f_open_char(&f, MemCard, FA_READ|FA_OPEN_EXISTING) != FR_OK) && IsTRIGame == 0 )
 		{
 			// Memory card file not found. Create it.
 			if(GenerateMemCard(MemCard, BI2region) == false)


### PR DESCRIPTION
Se si avvia per la prima volta un gioco Triforce, non vengono soltanto creati i salvataggi per le impostazioni e per la card, ma viene creato anche un file di tipo Memory Card per GC che risulta perfettamente inutile. Con questa modifica, il file in questione non viene più creato.
Per la cronaca, il file di codice che gestisce i salvataggi Triforce è il file TRI.c che si trova nella stessa directory.